### PR TITLE
added group read/write permissions

### DIFF
--- a/laravel/recipes/storage_permissions.rb
+++ b/laravel/recipes/storage_permissions.rb
@@ -5,6 +5,8 @@ node[:deploy].each do |application, deploy|
     cwd "#{deploy[:deploy_to]}/current"
     code <<-EOH
     chmod -R 777 storage/app storage/framework storage/logs
+    chmod gu+w bootstrap/cache
+    chmod gu+w storage/framework/sessions
     EOH
   end
 end


### PR DESCRIPTION
even with a global read/write it still appears that in some cases the group was not properly able to write to directories under random deployments.